### PR TITLE
Update ld2410.yaml

### DIFF
--- a/ld2410.yaml
+++ b/ld2410.yaml
@@ -30,7 +30,7 @@ wifi:
 captive_portal:
 
 uart:
-  id: uart1
+  id: uart_0
   tx_pin: TX
   rx_pin: RX
   baud_rate: 256000 # Change this according to your setting
@@ -44,7 +44,7 @@ uart:
       
 custom_component:
   - lambda: |-
-      return {new LD2410(id(uart1))};
+      return {new LD2410(id(uart_0))};
     components:
       - id: ld2410
       


### PR DESCRIPTION
ESPHome 2023.4.0 had a breaking change for UART.

"Due to uart0 / uart1 / uart2 being defined in some of the platform code ESPHome uses, ESPHome will now disallow these ids from being used in the config. You can simply change them to uart_0 to continue using."